### PR TITLE
Gallery fix for gallery nav circles rendering inside the 'Next' button.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,4 +10,4 @@ projectName = wireframe
 appName = com.enonic.app.wireframe
 displayName = Wireframe
 xpVersion = 6.5.0
-version = 1.0.1
+version = 1.0.2

--- a/src/main/resources/site/parts/sample-gallery/sample-gallery.html
+++ b/src/main/resources/site/parts/sample-gallery/sample-gallery.html
@@ -1,8 +1,8 @@
 <div class="sample-gallery">
     <h2 data-th-if="${label}" data-th-text="${label}"></h2>
     <div class="sample-gallery__image" data-th-classappend="'sample-gallery__image--' + ${aspectRatio}">
-        <button class="sample-gallery__prev"/>
-        <button class="sample-gallery__next"/>
+        <button class="sample-gallery__prev"></button>
+        <button class="sample-gallery__next"></button>
         <ul class="sample-gallery__nav">
             <li class="sample-gallery__nav-item sample-gallery__nav-item--active"></li>
             <li class="sample-gallery__nav-item"></li>

--- a/src/main/resources/site/parts/sample-video/sample-video.html
+++ b/src/main/resources/site/parts/sample-video/sample-video.html
@@ -1,7 +1,7 @@
 <div class="sample-video">
     <h2 data-th-if="${label}" data-th-text="${label}"></h2>
     <div class="sample-video__player" data-th-classappend="'sample-video__player--' + ${aspectRatio}">
-        <button class="sample-video__play"/>
+        <button class="sample-video__play"></button>
 
         <div class="sample-video__ctrl">
             <div class="sample-video__ctrl-play"></div>


### PR DESCRIPTION
The gallery nav circles are being rendered inside of the "next" button on XP version 6.6.0. It seems like thymeleaf doesn't like self-closed button elements. Fixed it by adding a closing tag to the button elements.  Also set version to 1.0.2.