### PR TITLE
Fix rendering bugs from self-closed button elements

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,4 +10,4 @@ projectName = wireframe
 appName = com.enonic.app.wireframe
 displayName = Wireframe
 xpVersion = 6.5.0
-version = 1.0.1
+version = 1.0.2

--- a/src/main/resources/site/parts/sample-gallery/sample-gallery.html
+++ b/src/main/resources/site/parts/sample-gallery/sample-gallery.html
@@ -1,8 +1,8 @@
 <div class="sample-gallery">
     <h2 data-th-if="${label}" data-th-text="${label}"></h2>
     <div class="sample-gallery__image" data-th-classappend="'sample-gallery__image--' + ${aspectRatio}">
-        <button class="sample-gallery__prev"/>
-        <button class="sample-gallery__next"/>
+        <button class="sample-gallery__prev"></button>
+        <button class="sample-gallery__next"></button>
         <ul class="sample-gallery__nav">
             <li class="sample-gallery__nav-item sample-gallery__nav-item--active"></li>
             <li class="sample-gallery__nav-item"></li>

--- a/src/main/resources/site/parts/sample-video/sample-video.html
+++ b/src/main/resources/site/parts/sample-video/sample-video.html
@@ -1,7 +1,7 @@
 <div class="sample-video">
     <h2 data-th-if="${label}" data-th-text="${label}"></h2>
     <div class="sample-video__player" data-th-classappend="'sample-video__player--' + ${aspectRatio}">
-        <button class="sample-video__play"/>
+        <button class="sample-video__play"></button>
 
         <div class="sample-video__ctrl">
             <div class="sample-video__ctrl-play"></div>


### PR DESCRIPTION
Maybe it's just Chrome or maybe there was a change to the 6.6.0 Thymeleaf, but it seems that whatever element comes after a self-closed button element gets put inside of the button element. This caused all of the gallery nav circles to render inside of the "Next" button and all the video controls to render inside the play button.