### PR TITLE
Bump version to 2.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            1.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds the `releaseBranch:` block to `.github/workflows/enonic-gradle.yml` so both `master` and the new `1.x` maintenance branch are recognized as release branches by `enonic/release-tools/build-and-publish`.

`gradle.properties` already declares `version=2.0.0-SNAPSHOT`, so no version-field change is needed on master.

The companion PR against `1.x` is required so pushes to `1.x` are recognized as release-branch builds (the action reads `releaseBranch:` from the branch's own workflow file).

## Test plan
- [ ] CI green on this PR
- [ ] After merge, `./gradlew clean build` from master is green