### PR TITLE
Fix XP 8 runtime errors #576

### DIFF
--- a/src/main/resources/cms/layouts/layout-1-col/layout-1-col.js
+++ b/src/main/resources/cms/layouts/layout-1-col/layout-1-col.js
@@ -1,7 +1,7 @@
 var libs = {
     portal: require('/lib/xp/portal'),
     thymeleaf: require('/lib/thymeleaf'),
-    util: require('/lib/util')
+    util: require('/lib/util/region')
 };
 
 // Handle GET request
@@ -16,7 +16,7 @@ function handleGet(req) {
         var model = {};
         model.layoutBaseClass = getLayoutBaseClass();
         model.fullWidth = component.config.fullWidth ? true : false;
-        model.regions = libs.util.region.get();
+        model.regions = libs.util.get();
 
         return model;
     }

--- a/src/main/resources/cms/layouts/layout-2-col/layout-2-col.js
+++ b/src/main/resources/cms/layouts/layout-2-col/layout-2-col.js
@@ -1,7 +1,7 @@
 var libs = {
     portal: require('/lib/xp/portal'),
     thymeleaf: require('/lib/thymeleaf'),
-    util: require('/lib/util')
+    util: require('/lib/util/region')
 };
 
 // Handle GET request
@@ -16,7 +16,7 @@ function handleGet(req) {
         var model = {};
         model.layoutBaseClass = getLayoutBaseClass();
         model.fullWidth = component.config.fullWidth ? true : false;
-        model.regions = libs.util.region.get();
+        model.regions = libs.util.get();
         return model;
     }
 

--- a/src/main/resources/cms/layouts/layout-3-col/layout-3-col.js
+++ b/src/main/resources/cms/layouts/layout-3-col/layout-3-col.js
@@ -1,7 +1,7 @@
 var libs = {
     portal: require('/lib/xp/portal'),
     thymeleaf: require('/lib/thymeleaf'),
-    util: require('/lib/util')
+    util: require('/lib/util/region')
 };
 
 // Handle GET request
@@ -16,7 +16,7 @@ function handleGet(req) {
         var model = {};
         model.layoutBaseClass = getLayoutBaseClass();
         model.fullWidth = component.config.fullWidth ? true : false;
-        model.regions = libs.util.region.get();
+        model.regions = libs.util.get();
         return model;
     }
 

--- a/src/main/resources/cms/layouts/layout-4-col/layout-4-col.js
+++ b/src/main/resources/cms/layouts/layout-4-col/layout-4-col.js
@@ -1,7 +1,7 @@
 var libs = {
     portal: require('/lib/xp/portal'),
     thymeleaf: require('/lib/thymeleaf'),
-    util: require('/lib/util')
+    util: require('/lib/util/region')
 };
 
 // Handle GET request
@@ -16,7 +16,7 @@ function handleGet(req) {
         var model = {};
         model.layoutBaseClass = getLayoutBaseClass();
         model.fullWidth = component.config.fullWidth ? true : false;
-        model.regions = libs.util.region.get();
+        model.regions = libs.util.get();
         return model;
     }
 

--- a/src/main/resources/cms/pages/default/default.js
+++ b/src/main/resources/cms/pages/default/default.js
@@ -2,7 +2,7 @@ var libs = {
     portal: require('/lib/xp/portal'),
     thymeleaf: require('/lib/thymeleaf'),
     menu: require('/lib/menu'),
-    util: require('/lib/util')
+    util: require('/lib/util/data')
 };
 
 // Handle GET request
@@ -24,12 +24,12 @@ function handleGet(req) {
         model.currentPath = content._path;
         model.pageTitle = getPageTitle();
         model.metaDescription = getMetaDescription();
-        model.menuItems = libs.menu.getMenuTree(3);
+        model.menuItems = libs.menu.getMenuTree(3).menuItems;
         model.companyName = siteConfig.companyName;
 
         model.showFooterNav = siteConfig.footerNavigation ? true : false;
-        model.footerSocial = libs.util.data.forceArray(siteConfig.footerSocial);
-        model.footerSocial = libs.util.data.trimArray(model.footerSocial);
+        model.footerSocial = libs.util.forceArray(siteConfig.footerSocial);
+        model.footerSocial = libs.util.trimArray(model.footerSocial);
         model.footerText = siteConfig.footerText;
 
         model.showFooter = model.showFooterNav || model.footerSocial.length > 0 || model.footerText;

--- a/src/main/resources/cms/parts/breadcrumbs/breadcrumbs.js
+++ b/src/main/resources/cms/parts/breadcrumbs/breadcrumbs.js
@@ -2,7 +2,6 @@ var libs = {
     portal: require('/lib/xp/portal'),
     thymeleaf: require('/lib/thymeleaf'),
     content: require('/lib/xp/content'),
-    util: require('/lib/util'),
     menu: require('/lib/menu')
 };
 

--- a/src/main/resources/cms/parts/heading/heading.js
+++ b/src/main/resources/cms/parts/heading/heading.js
@@ -1,7 +1,6 @@
 var libs = {
     portal: require('/lib/xp/portal'),
-    thymeleaf: require('/lib/thymeleaf'),
-    util: require('/lib/util')
+    thymeleaf: require('/lib/thymeleaf')
 };
 
 // Handle GET request

--- a/src/main/resources/cms/parts/sample-form/sample-form.js
+++ b/src/main/resources/cms/parts/sample-form/sample-form.js
@@ -1,7 +1,7 @@
 var libs = {
     portal: require('/lib/xp/portal'),
     thymeleaf: require('/lib/thymeleaf'),
-    util: require('/lib/util')
+    util: require('/lib/util/data')
 };
 
 // Handle GET request
@@ -22,8 +22,8 @@ function handleGet(req) {
 
     function getFormRows() {
         var formRows = component.config.formRow;
-        formRows = libs.util.data.forceArray(formRows);
-        formRows = libs.util.data.trimArray(formRows);
+        formRows = libs.util.forceArray(formRows);
+        formRows = libs.util.trimArray(formRows);
         return formRows;
     }
 

--- a/src/main/resources/cms/parts/sample-gallery/sample-gallery.js
+++ b/src/main/resources/cms/parts/sample-gallery/sample-gallery.js
@@ -1,7 +1,6 @@
 var libs = {
     portal: require('/lib/xp/portal'),
-    thymeleaf: require('/lib/thymeleaf'),
-    util: require('/lib/util')
+    thymeleaf: require('/lib/thymeleaf')
 };
 
 // Handle GET request

--- a/src/main/resources/cms/parts/sample-image/sample-image.js
+++ b/src/main/resources/cms/parts/sample-image/sample-image.js
@@ -1,7 +1,6 @@
 var libs = {
     portal: require('/lib/xp/portal'),
-    thymeleaf: require('/lib/thymeleaf'),
-    util: require('/lib/util')
+    thymeleaf: require('/lib/thymeleaf')
 };
 
 // Handle GET request

--- a/src/main/resources/cms/parts/sample-map/sample-map.js
+++ b/src/main/resources/cms/parts/sample-map/sample-map.js
@@ -1,7 +1,6 @@
 var libs = {
     portal: require('/lib/xp/portal'),
-    thymeleaf: require('/lib/thymeleaf'),
-    util: require('/lib/util')
+    thymeleaf: require('/lib/thymeleaf')
 };
 
 // Handle GET request

--- a/src/main/resources/cms/parts/sample-text/sample-text.js
+++ b/src/main/resources/cms/parts/sample-text/sample-text.js
@@ -1,7 +1,6 @@
 var libs = {
     portal: require('/lib/xp/portal'),
-    thymeleaf: require('/lib/thymeleaf'),
-    util: require('/lib/util')
+    thymeleaf: require('/lib/thymeleaf')
 };
 
 // Handle GET request

--- a/src/main/resources/cms/parts/sample-video/sample-video.js
+++ b/src/main/resources/cms/parts/sample-video/sample-video.js
@@ -1,7 +1,6 @@
 var libs = {
     portal: require('/lib/xp/portal'),
-    thymeleaf: require('/lib/thymeleaf'),
-    util: require('/lib/util')
+    thymeleaf: require('/lib/thymeleaf')
 };
 
 // Handle GET request

--- a/src/main/resources/main.js
+++ b/src/main/resources/main.js
@@ -17,7 +17,8 @@ function runInContext(callback) {
     try {
         result = contextLib.run({
             principals: ["role:system.admin"],
-            repository: 'com.enonic.cms.' + projectData.id
+            repository: 'com.enonic.cms.' + projectData.id,
+            branch: 'master'
         }, callback);
     } catch (e) {
         log.info('Error: ' + e.message);


### PR DESCRIPTION
## Summary

End-to-end verification on XP 8.0.0-B4 (the version declared in `gradle.properties`) showed three runtime regressions that the dependency upgrade in #570 / #571 didn't surface (note in #570: *"Runtime verification was not performed in the upgrade environment"*). After this patch, every page in the auto-imported `acme-wireframe` demo site renders cleanly.

### Issues fixed

**1. `main.js` — imported demo content unreachable**
`contextLib.run({repository, ...})` inherits the branch from the parent context, and at app-startup that context has no branch. The original code worked in XP 7 because the bootstrap context defaulted to `master`; in XP 8 the call falls through to `InternalContext`'s `requireNonNull(branch, "branch is required")` and `exportLib.importNodes` failed silently inside the try/catch — log line:
```
INFO  com.enonic.app.wireframe - (/main.js) Error: branch is required
```
Set `branch: 'master'` explicitly so the demo content lands in master and is visible to anonymous portal requests.

**2. 13 controllers — `require('/lib/util')` blows up on portal context**
The umbrella module `lib/util/index.js` eagerly loads `lib/util/portal/getLocale.js`, which calls `require('/lib/xp/admin')` at module-load. `/lib/xp/admin` is admin-context only; on a `/site/...` request it's not resolvable and the controller dies with:
```
{"status":500,"message":"Resource [com.enonic.app.wireframe:/lib/xp/admin] was not found"}
```
Switch each controller to the actual submodule it uses (`/lib/util/data` for `forceArray`/`trimArray`, `/lib/util/region` for `region.get`), and drop the require entirely from controllers that never referenced `libs.util`.

**3. `default.js` — `menuItems` template binding**
`lib-menu`'s `getMenuTree` returns `{menuItems, ariaLabel}`, but `default.html`'s `#lists.isEmpty(menuItems)` needs the array. Unwrap to `.menuItems`. Without the unwrap the template throws:
```
Exception evaluating OGNL expression: "#lists.isEmpty(menuItems)"
```

### E2E result after patch (XP 8.0.0-B4)

```
$ curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8080/site/wireframe/master/acme-wireframe
200
$ curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8080/site/wireframe/master/acme-wireframe/about-us
200
$ curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8080/site/wireframe/master/acme-wireframe/contact-us
200
$ curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8080/site/wireframe/master/acme-wireframe/gallery
200
$ curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8080/site/wireframe/master/acme-wireframe/videos
200
```

`server.log` is free of `ERROR`/`Exception` lines for the wireframe bundle, and the auto-import logs all 7 expected nodes.

Closes #576

## Test plan

- [x] `./gradlew build` green
- [x] xp-distro at 8.0.0-B4 boots with the rebuilt `wireframe.jar` dropped in `home/deploy/`
- [x] log shows `Started application com.enonic.app.wireframe`
- [x] log shows the 7 imported nodes under `/content/acme-wireframe`
- [x] anonymous GETs to the 5 demo pages all return 200
- [x] no `ERROR`/`Exception` lines attributable to the wireframe bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)