### PR TITLE
Migrate to XP 8 lib-project API

### DIFF
--- a/src/main/resources/main.js
+++ b/src/main/resources/main.js
@@ -7,9 +7,7 @@ const projectData = {
     id: 'wireframe',
     displayName: 'Wireframe',
     description: 'Demo site for the wireframe app',
-    readAccess: {
-        public: true
-    }
+    publicRead: true
 }
 
 function runInContext(callback) {


### PR DESCRIPTION
Migrates the `projectLib.create(...)` call in `src/main/resources/main.js` to the new flat `publicRead: boolean` shape introduced for XP 8 in enonic/xp#12043 — the old nested `readAccess: { public }` form has no backward-compat shim and fails at runtime on XP 8.

This is a one-line change: `readAccess: { public: true }` → `publicRead: true`. No other lib-project APIs are touched by the app (no `modify`, no `modifyReadAccess`), and no other XP libs are bumped.

See also: `enonic/doc-code` → `docs/upgrade.adoc` (lib-project section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)