### PR TITLE
Modernize demo importer #586

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     include xplibs.cluster
     include xplibs.context
     include xplibs.export
+    include xplibs.task
 
     include libs.lib.menu
     include libs.lib.thymeleaf

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,5 +8,5 @@
 group = com.enonic.app
 projectName = wireframe
 appName = com.enonic.app.wireframe
-xpVersion = 8.0.0-B4
+xpVersion = 8.0.0-RC1
 version = 2.0.0-SNAPSHOT

--- a/src/main/resources/import/acme-wireframe/_/node.xml
+++ b/src/main/resources/import/acme-wireframe/_/node.xml
@@ -2,10 +2,9 @@
     <id>d53cda50-9a0c-42d3-8594-cc1d5575b2a3</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-04-03T09:09:16.972Z</timestamp>
-    <inheritPermissions>false</inheritPermissions>
+    <timestamp>2026-05-29T13:30:17.404Z</timestamp>
     <permissions>
-        <principal key="role:cms.cm.app">
+        <principal key="role:system.everyone">
             <allow type="array">
                 <value>READ</value>
             </allow>
@@ -35,7 +34,46 @@
             </allow>
             <deny type="array"/>
         </principal>
-        <principal key="role:system.everyone">
+        <principal key="role:cms.project.wireframe.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.wireframe.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.wireframe.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.wireframe.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.wireframe.viewer">
             <allow type="array">
                 <value>READ</value>
             </allow>
@@ -218,6 +256,11 @@
                 <string name="value">&lt;p&gt;Item title&lt;br /&gt;Item category&lt;br /&gt;$9.99&lt;/p&gt;</string>
             </property-set>
         </property-set>
+        <property-set name="publish">
+            <dateTime name="time">2026-05-29T13:29:57.629Z</dateTime>
+            <dateTime name="from">2026-05-29T13:29:57.505Z</dateTime>
+            <dateTime name="first">2026-05-29T13:29:57.505Z</dateTime>
+        </property-set>
     </data>
     <indexConfigs>
         <defaultConfig>
@@ -289,7 +332,7 @@
                         <indexValueProcessor>htmlStripper</indexValueProcessor>
                     </indexValueProcessors>
                 </indexConfig>
-                <path>data.siteConfig.config.footerText</path>
+                <path>data.siteconfig.config.footertext</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -299,7 +342,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>data.siteConfig.applicationkey</path>
+                <path>data.siteconfig.applicationkey</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -452,7 +495,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -482,7 +525,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -505,6 +548,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/acme-wireframe/_templates/_/node.xml
+++ b/src/main/resources/import/acme-wireframe/_templates/_/node.xml
@@ -2,10 +2,9 @@
     <id>93dd1152-8af9-4e7a-9dfd-679a87e8d1e2</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-04-03T09:09:17.075Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T13:30:17.427Z</timestamp>
     <permissions>
-        <principal key="role:cms.cm.app">
+        <principal key="role:system.everyone">
             <allow type="array">
                 <value>READ</value>
             </allow>
@@ -35,7 +34,46 @@
             </allow>
             <deny type="array"/>
         </principal>
-        <principal key="role:system.everyone">
+        <principal key="role:cms.project.wireframe.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.wireframe.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.wireframe.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.wireframe.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.wireframe.viewer">
             <allow type="array">
                 <value>READ</value>
             </allow>
@@ -52,6 +90,11 @@
         <dateTime name="modifiedTime">2016-08-23T07:51:56.757Z</dateTime>
         <string name="owner">user:system:su</string>
         <property-set name="data"/>
+        <property-set name="publish">
+            <dateTime name="time">2026-05-29T13:29:57.675Z</dateTime>
+            <dateTime name="from">2026-05-29T13:29:57.505Z</dateTime>
+            <dateTime name="first">2026-05-29T13:29:57.505Z</dateTime>
+        </property-set>
     </data>
     <indexConfigs>
         <defaultConfig>
@@ -130,7 +173,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -160,7 +203,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -173,6 +216,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/acme-wireframe/_templates/default/_/node.xml
+++ b/src/main/resources/import/acme-wireframe/_templates/default/_/node.xml
@@ -2,10 +2,9 @@
     <id>891c6d55-93aa-425a-97f6-141212a0a986</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-04-03T09:09:17.085Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T13:30:17.468Z</timestamp>
     <permissions>
-        <principal key="role:cms.cm.app">
+        <principal key="role:system.everyone">
             <allow type="array">
                 <value>READ</value>
             </allow>
@@ -35,7 +34,46 @@
             </allow>
             <deny type="array"/>
         </principal>
-        <principal key="role:system.everyone">
+        <principal key="role:cms.project.wireframe.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.wireframe.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.wireframe.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.wireframe.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.wireframe.viewer">
             <allow type="array">
                 <value>READ</value>
             </allow>
@@ -67,6 +105,11 @@
                     </property-set>
                 </property-set>
             </property-set>
+        </property-set>
+        <property-set name="publish">
+            <dateTime name="time">2026-05-29T13:29:57.695Z</dateTime>
+            <dateTime name="from">2026-05-29T13:29:57.505Z</dateTime>
+            <dateTime name="first">2026-05-29T13:29:57.505Z</dateTime>
         </property-set>
     </data>
     <indexConfigs>
@@ -239,7 +282,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -269,7 +312,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -292,6 +335,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/acme-wireframe/about-us/_/node.xml
+++ b/src/main/resources/import/acme-wireframe/about-us/_/node.xml
@@ -2,10 +2,9 @@
     <id>41c7fc79-7d4f-4bfb-8a5d-7d38ee3cb22a</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-04-03T09:09:17.038Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T13:30:17.433Z</timestamp>
     <permissions>
-        <principal key="role:cms.cm.app">
+        <principal key="role:system.everyone">
             <allow type="array">
                 <value>READ</value>
             </allow>
@@ -35,7 +34,46 @@
             </allow>
             <deny type="array"/>
         </principal>
-        <principal key="role:system.everyone">
+        <principal key="role:cms.project.wireframe.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.wireframe.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.wireframe.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.wireframe.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.wireframe.viewer">
             <allow type="array">
                 <value>READ</value>
             </allow>
@@ -150,6 +188,11 @@
                     </property-set>
                 </property-set>
             </property-set>
+        </property-set>
+        <property-set name="publish">
+            <dateTime name="time">2026-05-29T13:29:57.712Z</dateTime>
+            <dateTime name="from">2026-05-29T13:29:57.505Z</dateTime>
+            <dateTime name="first">2026-05-29T13:29:57.505Z</dateTime>
         </property-set>
     </data>
     <indexConfigs>
@@ -382,7 +425,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -412,7 +455,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -435,6 +478,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/acme-wireframe/contact-us/_/node.xml
+++ b/src/main/resources/import/acme-wireframe/contact-us/_/node.xml
@@ -2,10 +2,9 @@
     <id>4cbe1e43-8d29-4667-9d7d-a518d895ac35</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-04-03T09:09:17.026Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T13:30:17.441Z</timestamp>
     <permissions>
-        <principal key="role:cms.cm.app">
+        <principal key="role:system.everyone">
             <allow type="array">
                 <value>READ</value>
             </allow>
@@ -35,7 +34,46 @@
             </allow>
             <deny type="array"/>
         </principal>
-        <principal key="role:system.everyone">
+        <principal key="role:cms.project.wireframe.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.wireframe.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.wireframe.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.wireframe.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.wireframe.viewer">
             <allow type="array">
                 <value>READ</value>
             </allow>
@@ -185,6 +223,11 @@
                 <string name="value">&lt;p&gt;ACME, Inc.&lt;br /&gt;123 Acme Road&lt;br /&gt;Acme City, CA 90403&lt;/p&gt;
 &lt;p&gt;+47-555-555-1234.&lt;/p&gt;</string>
             </property-set>
+        </property-set>
+        <property-set name="publish">
+            <dateTime name="time">2026-05-29T13:29:57.739Z</dateTime>
+            <dateTime name="from">2026-05-29T13:29:57.505Z</dateTime>
+            <dateTime name="first">2026-05-29T13:29:57.505Z</dateTime>
         </property-set>
     </data>
     <indexConfigs>
@@ -427,7 +470,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -457,7 +500,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -480,6 +523,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/acme-wireframe/gallery/_/node.xml
+++ b/src/main/resources/import/acme-wireframe/gallery/_/node.xml
@@ -2,10 +2,9 @@
     <id>5d837a5f-161f-440c-ba68-537921c0d1a5</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-04-03T09:09:17.065Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T13:30:17.451Z</timestamp>
     <permissions>
-        <principal key="role:cms.cm.app">
+        <principal key="role:system.everyone">
             <allow type="array">
                 <value>READ</value>
             </allow>
@@ -35,7 +34,46 @@
             </allow>
             <deny type="array"/>
         </principal>
-        <principal key="role:system.everyone">
+        <principal key="role:cms.project.wireframe.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.wireframe.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.wireframe.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.wireframe.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.wireframe.viewer">
             <allow type="array">
                 <value>READ</value>
             </allow>
@@ -120,6 +158,11 @@
                     </property-set>
                 </property-set>
             </property-set>
+        </property-set>
+        <property-set name="publish">
+            <dateTime name="time">2026-05-29T13:29:57.777Z</dateTime>
+            <dateTime name="from">2026-05-29T13:29:57.505Z</dateTime>
+            <dateTime name="first">2026-05-29T13:29:57.505Z</dateTime>
         </property-set>
     </data>
     <indexConfigs>
@@ -332,7 +375,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -362,7 +405,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -385,6 +428,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/acme-wireframe/videos/_/node.xml
+++ b/src/main/resources/import/acme-wireframe/videos/_/node.xml
@@ -2,10 +2,9 @@
     <id>1817fa93-23b9-4f09-8bf1-9eea090c9278</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-04-03T09:09:17.050Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T13:30:17.458Z</timestamp>
     <permissions>
-        <principal key="role:cms.cm.app">
+        <principal key="role:system.everyone">
             <allow type="array">
                 <value>READ</value>
             </allow>
@@ -35,7 +34,46 @@
             </allow>
             <deny type="array"/>
         </principal>
-        <principal key="role:system.everyone">
+        <principal key="role:cms.project.wireframe.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.wireframe.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.wireframe.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.wireframe.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.wireframe.viewer">
             <allow type="array">
                 <value>READ</value>
             </allow>
@@ -222,6 +260,11 @@
                     </property-set>
                 </property-set>
             </property-set>
+        </property-set>
+        <property-set name="publish">
+            <dateTime name="time">2026-05-29T13:29:57.798Z</dateTime>
+            <dateTime name="from">2026-05-29T13:29:57.505Z</dateTime>
+            <dateTime name="first">2026-05-29T13:29:57.505Z</dateTime>
         </property-set>
     </data>
     <indexConfigs>
@@ -454,7 +497,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -484,7 +527,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -507,6 +550,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/replace_app.xsl
+++ b/src/main/resources/import/replace_app.xsl
@@ -1,19 +1,54 @@
 <?xml version="1.0"?>
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-    <xsl:output method="xml" indent="yes"/>
-    <xsl:param name="keepPublishFirst" select="'true'"/>
+  <xsl:output method="xml" indent="yes"/>
 
-    <xsl:template match="data/property-set[@name='publish']">
-        <xsl:if test="$keepPublishFirst != 'false'">
-            <xsl:copy>
-                <xsl:apply-templates select="@*|*[@name='first']"/>
-            </xsl:copy>
-        </xsl:if>
-    </xsl:template>
+  <xsl:param name="applicationId"/>
+  <xsl:param name="projectName"/>
+  <xsl:param name="keepPublishFirst" select="'true'"/>
 
-    <xsl:template match="@*|node()">
-        <xsl:copy>
-            <xsl:apply-templates select="@*|node()"/>
-        </xsl:copy>
-    </xsl:template>
+  <!-- Values the bundled /import data was exported with -->
+  <xsl:variable name="applicationIdPlaceholder" select="'com.enonic.app.wireframe'"/>
+  <xsl:variable name="projectNamePlaceholder" select="'wireframe'"/>
+
+  <xsl:variable name="applicationIdDashed" select="translate($applicationId, '.', '-')"/>
+  <xsl:variable name="applicationIdPlaceholderDashed" select="translate($applicationIdPlaceholder, '.', '-')"/>
+
+  <!-- app key inside descriptor-style string values: "<app>:descriptor" -->
+  <xsl:template match="string[starts-with(text(), concat($applicationIdPlaceholder, ':'))]">
+    <string>
+      <xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute>
+      <xsl:value-of select="concat($applicationId, substring-after(., $applicationIdPlaceholder))"/>
+    </string>
+  </xsl:template>
+
+  <!-- bare app key string value -->
+  <xsl:template match="string[text() = $applicationIdPlaceholder]">
+    <string>
+      <xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute>
+      <xsl:value-of select="$applicationId"/>
+    </string>
+  </xsl:template>
+
+  <!-- dashed app key in property-set names (x.<dashed-app>...) -->
+  <xsl:template match="property-set/@name[. = $applicationIdPlaceholderDashed]">
+    <xsl:attribute name="name"><xsl:value-of select="$applicationIdDashed"/></xsl:attribute>
+  </xsl:template>
+
+  <!-- project-role principals: role:cms.project.<placeholder>.<suffix> -->
+  <xsl:template match="principal/@key[starts-with(., concat('role:cms.project.', $projectNamePlaceholder, '.'))]">
+    <xsl:attribute name="key">
+      <xsl:value-of select="concat('role:cms.project.', $projectName, '.', substring-after(., concat('role:cms.project.', $projectNamePlaceholder, '.')))"/>
+    </xsl:attribute>
+  </xsl:template>
+
+  <xsl:template match="@*|node()">
+    <xsl:copy><xsl:apply-templates select="@*|node()"/></xsl:copy>
+  </xsl:template>
+
+  <!-- Remove publishing metadata on import -->
+  <xsl:template match="data/property-set[@name='publish']">
+    <xsl:if test="$keepPublishFirst != 'false'">
+      <xsl:copy><xsl:apply-templates select="@*|*[@name='first']"/></xsl:copy>
+    </xsl:if>
+  </xsl:template>
 </xsl:stylesheet>

--- a/src/main/resources/main.js
+++ b/src/main/resources/main.js
@@ -1,22 +1,29 @@
-const projectLib = require('/lib/xp/project');
 const contextLib = require('/lib/xp/context');
+const contentLib = require('/lib/xp/content');
 const clusterLib = require('/lib/xp/cluster');
 const exportLib = require('/lib/xp/export');
+const projectLib = require('/lib/xp/project');
+const taskLib = require('/lib/xp/task');
 
 const projectData = {
     id: 'wireframe',
     displayName: 'Wireframe',
     description: 'Demo site for the wireframe app',
-    publicRead: true
+    readAccess: {
+        public: true
+    }
 }
 
-function runInContext(callback) {
+const runInContext = function (callback) {
     let result;
     try {
         result = contextLib.run({
-            principals: ["role:system.admin"],
+            user: {
+                login: "su",
+                idProvider: "system"
+            },
             repository: 'com.enonic.cms.' + projectData.id,
-            branch: 'master'
+            branch: 'draft'
         }, callback);
     } catch (e) {
         log.info('Error: ' + e.message);
@@ -25,33 +32,44 @@ function runInContext(callback) {
     return result;
 }
 
-function createProject() {
+const createProject = function () {
     return projectLib.create(projectData);
 }
 
-function getProject() {
+const getProject = function () {
     return projectLib.get({
         id: projectData.id
     });
 }
 
-function initializeProject() {
-    let project = runInContext(getProject);
+const initialize = function () {
+    runInContext(() => {
+        const project = getProject();
+        if (!project) {
+            taskLib.executeFunction({
+                description: 'Importing content',
+                func: initProject
+            });
+        }
+        else {
+            log.debug(`Project ${project.id} exists, skipping import`);
+        }
+    });
+};
 
-    if (!project) {
-        log.info('Project "' + projectData.id + '" not found. Creating...');
-        project = runInContext(createProject);
+const initProject = function () {
+    runInContext(() => {
+        const project = createProject();
 
         if (project) {
             log.info('Project "' + projectData.id + '" successfully created');
-
-            log.info('Importing "' + projectData.id + '" data');
-            runInContext(createContent);
+            createContent();
+            publishRoot();
         } else {
-            log.error('Project "' + projectData.id + '" failed to be created');
+            log.error('Project "' + projectData.id + '" creation failed');
         }
-    }
-}
+    });
+};
 
 function createContent() {
     let importNodes = exportLib.importNodes({
@@ -59,34 +77,40 @@ function createContent() {
         targetNodePath: '/content',
         xslt: resolve('/import/replace_app.xsl'),
         xsltParams: {
-            applicationId: app.name
+            applicationId: app.name,
+            projectName: projectData.id
         },
         versionAttributes: {
             'content.import': {
-                user: "role:system.admin",
+                user: contextLib.get().authInfo.user.key,
                 optime: new Date().toISOString()
             },
             'vacuum.skip': {}
         },
         includeNodeIds: true
     });
-    log.info('-------------------');
-    log.info('Imported nodes:');
-    importNodes.addedNodes.forEach(element => log.info(element));
-    log.info('-------------------');
-    log.info('Updated nodes:');
-    importNodes.updatedNodes.forEach(element => log.info(element));
-    log.info('-------------------');
-    log.info('Imported binaries:');
-    importNodes.importedBinaries.forEach(element => log.info(element));
-    log.info('-------------------');
-    if (importNodes.importErrors.length !== 0) {
+    if (importNodes.importErrors.length > 0) {
         log.warning('Errors:');
         importNodes.importErrors.forEach(element => log.warning(element.message));
         log.info('-------------------');
     }
 }
 
-if (clusterLib.isMaster()) {
-    initializeProject();
+function publishRoot() {
+    const result = contentLib.publish({
+        keys: ['/acme-wireframe'],
+        sourceBranch: 'draft',
+        targetBranch: 'master',
+        includeChildren: true,
+        includeDependencies: true,
+    });
+    if (!result || (result.failedContents && result.failedContents.length > 0)) {
+        log.warning('Could not publish imported content. failed=' + JSON.stringify(result && result.failedContents));
+    } else {
+        log.info('Published ' + (result.pushedContents ? result.pushedContents.length : 0) + ' content items.');
+    }
+}
+
+if (clusterLib.isLeader()) {
+    initialize();
 }


### PR DESCRIPTION
Closes #586.

## Summary

Brings the bundled demo importer up to the same standard as the merged
[`app-superhero-blog#174`](https://github.com/enonic/app-superhero-blog/pull/174),
[`app-hmdb#80`](https://github.com/enonic/app-hmdb/pull/80), and
[`app-image-xpert#54`](https://github.com/enonic/app-image-xpert/pull/54).
The bundled data has no media nodes, so the sha512 step those PRs apply
does not apply here.

### `src/main/resources/import/replace_app.xsl`

Now fully parameter-driven. Takes:

- `applicationId` + `projectName` (live values, passed from `main.js`)
- `keepPublishFirst` (default `'true'`)

Placeholder values that the bundled `/import` data was exported with
(`com.enonic.app.wireframe` / `wireframe`) live as `<xsl:variable>`
inside the stylesheet, so callers don't need to know them. Templates
rewrite:

- `string` starting with `<placeholder>:` -> app prefix swapped to
  `$applicationId`
- bare `<placeholder>` string value -> `$applicationId`
- `property-set/@name` matching the dashed app placeholder -> dashed
  `$applicationId`
- `principal/@key` starting with `role:cms.project.<placeholder>.` ->
  project segment swapped to `$projectName`
- `data/property-set[@name='publish']` stripped (kept only `first`)

Forks that rename either the app key or the project id now get correct
descriptor refs and `role:cms.project.<new-id>.*` principals on imported
content.

### `src/main/resources/main.js`

Modernized to match the merged superhero/hmdb/image-xpert pattern:

- `projectData.readAccess.public = true` (replaces `publicRead: true`)
- `runInContext` uses `user: { login: 'su', idProvider: 'system' }`
  (drops `principals: ['role:system.admin']`)
- `xsltParams` passes only the live targets (`applicationId: app.name`,
  `projectName: projectData.id`)
- `versionAttributes['content.import'].user` is
  `contextLib.get().authInfo.user.key` instead of the hardcoded role
- `publishRoot()` added — calls `contentLib.publish` on `/acme-wireframe`
  with `includeChildren: true`, `includeDependencies: true`, inspects
  `failedContents`, logs `pushedContents.length`
- guard switched to `clusterLib.isLeader()`
- `taskLib.executeFunction({ description, func })` wraps the import

### Re-exported `/import/acme-wireframe` data

The 7 bundled `node.xml` files now carry the five canonical project-role
principals (`role:cms.project.wireframe.{owner,editor,author,contributor,viewer}`)
alongside `role:system.admin` / `role:cms.admin` / `role:system.everyone`,
applied via `contentLib.applyPermissions(scope: 'TREE')` in a one-off
bootstrap, then exported from `master` after publish and copied back.
`role:cms.cm.app` was dropped (matches the reference apps' baseline).

### Other

- `gradle.properties`: `xpVersion` bumped `8.0.0-B4` -> `8.0.0-RC1`. The
  B4-bundled `lib-project` does not have the `readAccess`-based API
  used by the modernized `main.js`.
- `build.gradle`: added `include xplibs.task` (for `taskLib.executeFunction`).

## Test plan

E2E inside `claude-dev` against `xp-distro` 8.0.0-SNAPSHOT:

- [x] `./gradlew build` green
- [x] Fresh xp-distro install, jar deployed, server.log shows:
  - `Started application com.enonic.app.wireframe`
  - `Project "wireframe" successfully created`
  - `Published 7 content items.`
  - no import errors / warnings
- [x] Source `/import/acme-wireframe` carries all five
  `role:cms.project.wireframe.*` principals on every node (7 x 5 = 35
  occurrences)