### PR TITLE
GraalJS Compatibility #599

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,6 @@ dependencies {
     testImplementation "com.enonic.xp:testing:${xpVersion}"
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:6.1.1'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:6.1.1'
-    testRuntimeOnly 'org.graalvm.polyglot:js:25.0.3'
 }
 
 node {
@@ -56,14 +55,6 @@ test {
     useJUnitPlatform()
 }
 
-def testGraalJs = tasks.register('testGraalJs', Test) {
-    group = 'verification'
-    description = 'Runs tests with the GraalJS script engine.'
-    useJUnitPlatform()
-    testClassesDirs = sourceSets.test.output.classesDirs
-    classpath = sourceSets.test.runtimeClasspath
-    systemProperty 'xp.script-engine', 'GraalJS'
-    shouldRunAfter test
+xp {
+    scriptEngines = ['Nashorn', 'GraalJS']
 }
-
-check.dependsOn testGraalJs

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,11 @@ dependencies {
 
     include libs.lib.menu
     include libs.lib.thymeleaf
+
+    testImplementation "com.enonic.xp:testing:${xpVersion}"
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:6.1.1'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:6.1.1'
+    testRuntimeOnly 'org.graalvm.polyglot:js:25.0.3'
 }
 
 node {
@@ -46,3 +51,19 @@ processResources {
 }
 
 jar.dependsOn webpack
+
+test {
+    useJUnitPlatform()
+}
+
+def testGraalJs = tasks.register('testGraalJs', Test) {
+    group = 'verification'
+    description = 'Runs tests with the GraalJS script engine.'
+    useJUnitPlatform()
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    systemProperty 'xp.script-engine', 'GraalJS'
+    shouldRunAfter test
+}
+
+check.dependsOn testGraalJs

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,5 +8,5 @@
 group = com.enonic.app
 projectName = wireframe
 appName = com.enonic.app.wireframe
-xpVersion = 8.0.2
+xpVersion = 8.1.0-SNAPSHOT
 version = 2.0.0-SNAPSHOT

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.enonic.xp.settings' version '4.1.0'
+    id 'com.enonic.xp.settings' version '4.2.0'
 }
 
 rootProject.name = projectName

--- a/src/main/resources/main.js
+++ b/src/main/resources/main.js
@@ -3,7 +3,6 @@ const contentLib = require('/lib/xp/content');
 const clusterLib = require('/lib/xp/cluster');
 const exportLib = require('/lib/xp/export');
 const projectLib = require('/lib/xp/project');
-const taskLib = require('/lib/xp/task');
 
 const projectData = {
     id: 'wireframe',
@@ -44,15 +43,8 @@ const getProject = function () {
 
 const initialize = function () {
     runInContext(() => {
-        const project = getProject();
-        if (!project) {
-            taskLib.executeFunction({
-                description: 'Importing content',
-                func: initProject
-            });
-        }
-        else {
-            log.debug(`Project ${project.id} exists, skipping import`);
+        if (!getProject()) {
+            initProject();
         }
     });
 };

--- a/src/test/java/com/enonic/app/wireframe/MainScriptTest.java
+++ b/src/test/java/com/enonic/app/wireframe/MainScriptTest.java
@@ -1,0 +1,13 @@
+package com.enonic.app.wireframe;
+
+import com.enonic.xp.testing.ScriptRunnerSupport;
+
+public class MainScriptTest
+    extends ScriptRunnerSupport
+{
+    @Override
+    public String getScriptTestFile()
+    {
+        return "/test/main-test.js";
+    }
+}

--- a/src/test/resources/test/main-test.js
+++ b/src/test/resources/test/main-test.js
@@ -1,0 +1,72 @@
+var t = require('/lib/xp/testing');
+
+var calls = {
+    projectGet: 0,
+    projectCreate: 0,
+    importNodes: 0,
+    publish: 0,
+    createdId: null
+};
+
+t.mock('/lib/xp/context.js', {
+    run: function (params, callback) {
+        return callback();
+    },
+    get: function () {
+        return {
+            authInfo: {
+                user: {
+                    key: 'user:system:su'
+                }
+            }
+        };
+    }
+});
+
+t.mock('/lib/xp/cluster.js', {
+    isLeader: function () {
+        return true;
+    }
+});
+
+t.mock('/lib/xp/project.js', {
+    get: function () {
+        calls.projectGet++;
+        return null;
+    },
+    create: function (params) {
+        calls.projectCreate++;
+        calls.createdId = params.id;
+        return {
+            id: params.id
+        };
+    }
+});
+
+t.mock('/lib/xp/export.js', {
+    importNodes: function () {
+        calls.importNodes++;
+        return {
+            importErrors: []
+        };
+    }
+});
+
+t.mock('/lib/xp/content.js', {
+    publish: function () {
+        calls.publish++;
+        return {
+            pushedContents: ['/acme-wireframe']
+        };
+    }
+});
+
+require('/main.js');
+
+exports.testInitImportsContentWhenProjectMissing = function () {
+    t.assertEquals(1, calls.projectGet, 'getProject should be called once');
+    t.assertEquals(1, calls.projectCreate, 'createProject should be called once');
+    t.assertEquals('wireframe', calls.createdId, 'created project id');
+    t.assertEquals(1, calls.importNodes, 'content should be imported');
+    t.assertEquals(1, calls.publish, 'root content should be published');
+};


### PR DESCRIPTION
Fixes #599

## What

`task.executeFunction` cannot run a closure on another thread under GraalJS — a function is bound to the context that created it — so it fails fast and the app cannot initialize on that engine. Since enonic/xp#12198 holds top-level execution until `main.js` completes, the init offload no longer serves a purpose. `main.js` now calls `initProject()` directly, and the now-unused `/lib/xp/task` require is dropped.

## Test on both engines

As prescribed in the issue, the tests run once per script engine:

- `testRuntimeOnly 'org.graalvm.polyglot:js:25.0.3'` plus a `testGraalJs` task wired into `check`.
- `xpVersion=8.1.0-SNAPSHOT` (for the `ScriptRunnerSupport` fix from enonic/xp#12198); `xp.enonicRepo('dev')` was already present.
- A `ScriptRunnerSupport` spec (`src/test/resources/test/main-test.js`) that mounts `main.js` with mocked `/lib/xp/*` and asserts the create → import → publish path runs.

Verified locally against a `publishToMavenLocal` build of enonic/xp#12198: both `test` (Nashorn) and `testGraalJs` (GraalJS) pass — 1 test each, 0 failures.

## Draft — CI note

Opened as a **draft**: the `dev` repository currently serves an `8.1.0-SNAPSHOT` without enonic/xp#12198, so **CI `testGraalJs` stays red until that PR is merged and a fresh snapshot is published**. The Nashorn `test` run is green. Reference: enonic/lib-sql#154.